### PR TITLE
feat: 계정 연동 시 accountID 중복확인 로직 추가

### DIFF
--- a/src/main/java/com/summoner/lolhaeduo/domain/account/repository/AccountRepository.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/account/repository/AccountRepository.java
@@ -4,4 +4,5 @@ import com.summoner.lolhaeduo.domain.account.entity.Account;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AccountRepository extends JpaRepository<Account, Long>, AccountQuerydslRepository{
+    boolean existsByUsername(String username);
 }

--- a/src/main/java/com/summoner/lolhaeduo/domain/account/service/AccountService.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/account/service/AccountService.java
@@ -33,6 +33,10 @@ public class AccountService {
             throw new IllegalArgumentException("Account limit(3) exceeded");
         }
 
+        if (accountRepository.existsByUsername(request.getAccountId())) {
+            throw new IllegalArgumentException("Account already exists");
+        }
+
         if (request.getAccountType().equals(AccountType.RIOT)) {
 
             PuuidResponse puuidResponse = riotUtil.extractPuuid(


### PR DESCRIPTION
## ✨ 담당 파트
- 계정 연동 시 accountID 중복확인 로직 추가

## 🔎 작업 상세 내용
- 이미 accountRepository에 해당 accountId로 등록된 계정이 있을 시, 에러를 반환합니다.

## 🔧 앞으로의 과제
- 이제 계정 연동은 끝난듯

## ✅ 테스트 코드 작성 및 기능 테스트 여부
- [] 테스트 코드 작성
- [x] 기능 테스트 여부

## ➕ 이슈 링크
- X