### PR TITLE
feat : 듀오 찾기 등록시 필요한 엔티티 수정, Dto 추가, RiotUtil에서 리그정보 가져오는 로직 추가

### DIFF
--- a/src/main/java/com/summoner/lolhaeduo/client/dto/LeagueEntryResponse.java
+++ b/src/main/java/com/summoner/lolhaeduo/client/dto/LeagueEntryResponse.java
@@ -1,0 +1,19 @@
+package com.summoner.lolhaeduo.client.dto;
+
+import lombok.Getter;
+
+@Getter
+public class LeagueEntryResponse {
+    String leagueId;
+    String summonerId;
+    String queueType;
+    String tier;
+    String rank;
+    int leaguePoints;
+    int wins;
+    int losses;
+    boolean hotStreak;
+    boolean veteran;
+    boolean freshBlood;
+    boolean inactive;
+}

--- a/src/main/java/com/summoner/lolhaeduo/client/riot/RiotUtil.java
+++ b/src/main/java/com/summoner/lolhaeduo/client/riot/RiotUtil.java
@@ -1,5 +1,6 @@
 package com.summoner.lolhaeduo.client.riot;
 
+import com.summoner.lolhaeduo.client.dto.LeagueEntryResponse;
 import com.summoner.lolhaeduo.client.dto.PuuidResponse;
 import com.summoner.lolhaeduo.client.dto.SummonerResponse;
 import com.summoner.lolhaeduo.domain.account.enums.AccountRegion;
@@ -56,4 +57,16 @@ public class RiotUtil {
         // Execute request
         return restTemplate.getForObject(url, SummonerResponse.class);
     }
+
+    public LeagueEntryResponse extractLeagueInfo(String summonerId, AccountServer server) {
+        String serverDomain = server.name().toLowerCase();
+
+        String url = String.format(
+                "https://%s.api.riotgames.com/lol/league/v4/entries/by-summoner/%s?api_key=%s",
+                serverDomain, summonerId, apiKey
+        );
+
+        return restTemplate.getForObject(url, LeagueEntryResponse.class);
+    }
+
 }

--- a/src/main/java/com/summoner/lolhaeduo/domain/duo/dto/DuoCreateRequest.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/duo/dto/DuoCreateRequest.java
@@ -1,0 +1,24 @@
+package com.summoner.lolhaeduo.domain.duo.dto;
+
+import com.summoner.lolhaeduo.domain.duo.enums.Lane;
+import com.summoner.lolhaeduo.domain.duo.enums.QueueType;
+import lombok.Getter;
+
+@Getter
+public class DuoCreateRequest {
+
+    private QueueType queueType;
+    private Lane primaryRole;
+    private String primaryChamp;
+    private Lane secondaryRole;
+    private String secondaryChamp;
+    private Lane targetRole;
+    private String memo;
+    private Boolean mic;
+
+
+    public void validate() {
+        // 여기서 null 체크
+        //
+    }
+}

--- a/src/main/java/com/summoner/lolhaeduo/domain/duo/dto/DuoCreateResponse.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/duo/dto/DuoCreateResponse.java
@@ -1,0 +1,36 @@
+package com.summoner.lolhaeduo.domain.duo.dto;
+
+import com.summoner.lolhaeduo.domain.duo.entity.Duo;
+import com.summoner.lolhaeduo.domain.duo.enums.Lane;
+import com.summoner.lolhaeduo.domain.duo.enums.QueueType;
+import lombok.Getter;
+
+@Getter
+public class DuoCreateResponse {
+
+    private Long id;
+    private QueueType queueType;
+    private Lane primaryRole;
+    private String primaryChamp;
+    private Lane secondaryRole;
+    private String secondaryChamp;
+    private Lane targetRole;
+    private String memo;
+    private Boolean mic;
+    private Long memberId;
+    private Long accountId;
+
+    public DuoCreateResponse(Duo duo) {
+        this.id = duo.getId();
+        this.queueType = duo.getQueueType();
+        this.primaryRole = duo.getPrimaryRole();
+        this.primaryChamp = duo.getPrimaryChamp();
+        this.secondaryRole = duo.getSecondaryRole();
+        this.secondaryChamp = duo.getSecondaryChamp();
+        this.targetRole = duo.getTargetRole();
+        this.memo = duo.getMemo();
+        this.mic = duo.getMic();
+        this.memberId = duo.getMemberId();
+        this.accountId = duo.getAccountId();
+    }
+}

--- a/src/main/java/com/summoner/lolhaeduo/domain/duo/entity/Duo.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/duo/entity/Duo.java
@@ -104,7 +104,7 @@ public class Duo extends Timestamped {
         this.accountId = accountId;
     }
 
-    public static Duo createQuickOf(QueueType queueType, Lane primaryRole, String primaryChamp, Lane secondaryRole, String secondaryChamp, Lane targetRole, String memo, Boolean mic, Long memberId, Long accountId) {
+    public static Duo quickOf(QueueType queueType, Lane primaryRole, String primaryChamp, Lane secondaryRole, String secondaryChamp, Lane targetRole, String memo, Boolean mic, Long memberId, Long accountId) {
         return new Duo(
                 queueType,
                 primaryRole,
@@ -119,7 +119,7 @@ public class Duo extends Timestamped {
         );
     }
 
-    public static Duo createRankOf(QueueType queueType, Lane primaryRole,Lane targetRole, String memo, Boolean mic, String tier, String rank, int wins, int losses, Long memberId, Long accountId) {
+    public static Duo rankOf(QueueType queueType, Lane primaryRole,Lane targetRole, String memo, Boolean mic, String tier, String rank, int wins, int losses, Long memberId, Long accountId) {
         return new Duo(
                 queueType,
                 primaryRole,

--- a/src/main/java/com/summoner/lolhaeduo/domain/duo/entity/Duo.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/duo/entity/Duo.java
@@ -65,6 +65,72 @@ public class Duo extends Timestamped {
 
     private LocalDateTime deletedAt;
 
+    private Duo(QueueType queueType, Lane primaryRole, String primaryChamp, Lane secondaryRole, String secondaryChamp,
+               Lane targetRole, String memo, Boolean mic, Long memberId, Long accountId) {
+        this.queueType = queueType;
+        this.primaryRole = primaryRole;
+        this.primaryChamp = primaryChamp;
+        this.secondaryRole = secondaryRole;
+        this.secondaryChamp = secondaryChamp;
+        this.targetRole = targetRole;
+        this.memo = memo;
+        this.mic = mic;
+        this.memberId = memberId;
+        this.accountId = accountId;
+    }
+
+    private Duo(QueueType queueType, Lane primaryRole, String primaryChamp, Lane secondaryRole, String secondaryChamp,
+               Lane targetRole, String memo, Boolean mic, String tier, String rank, int wins, int losses, Long memberId, Long accountId) {
+        this.queueType = queueType;
+        this.primaryRole = primaryRole;
+        this.primaryChamp = primaryChamp;
+        this.secondaryRole = secondaryRole;
+        this.secondaryChamp = secondaryChamp;
+        this.targetRole = targetRole;
+        this.memo = memo;
+        this.mic = mic;
+        this.tier = tier;
+        this.rank = rank;
+        this.wins = wins;
+        this.losses = losses;
+        this.memberId = memberId;
+        this.accountId = accountId;
+    }
+
+    public static Duo createQuickOf(QueueType queueType, Lane primaryRole, String primaryChamp, Lane secondaryRole, String secondaryChamp, Lane targetRole, String memo, Boolean mic, Long memberId, Long accountId) {
+        return new Duo(
+                queueType,
+                primaryRole,
+                primaryChamp,
+                secondaryRole,
+                secondaryChamp,
+                targetRole,
+                memo,
+                mic,
+                memberId,
+                accountId
+        );
+    }
+
+    public static Duo createRankOf(QueueType queueType, Lane primaryRole,Lane targetRole, String memo, Boolean mic, String tier, String rank, int wins, int losses, Long memberId, Long accountId) {
+        return new Duo(
+                queueType,
+                primaryRole,
+                null,
+                null,
+                null,
+                targetRole,
+                memo,
+                mic,
+                tier,
+                rank,
+                wins,
+                losses,
+                memberId,
+                accountId
+        );
+    }
+
 
 
 

--- a/src/main/java/com/summoner/lolhaeduo/domain/duo/entity/Duo.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/duo/entity/Duo.java
@@ -54,6 +54,8 @@ public class Duo extends Timestamped {
 
     private String favoritesChamp;
 
+    private Long profileIcon;
+
     @Embedded
     private Kda kda;
 

--- a/src/main/java/com/summoner/lolhaeduo/domain/duo/entity/Duo.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/duo/entity/Duo.java
@@ -44,6 +44,19 @@ public class Duo extends Timestamped {
 
     private Boolean mic;
 
+    private String tier;
+
+    private String rank;
+
+    private int wins;
+
+    private int losses;
+
+    private String favoritesChamp;
+
+    @Embedded
+    private Kda kda;
+
     @Column(nullable = false)
     private Long memberId;
 
@@ -52,40 +65,7 @@ public class Duo extends Timestamped {
 
     private LocalDateTime deletedAt;
 
-    private Duo(QueueType queueType, Lane primaryRole, String primaryChamp, Lane secondaryRole, String secondaryChamp,
-                Lane targetRole, String memo, Boolean mic, Long memberId, Long accountId) {
-        this.queueType = queueType;
-        this.primaryRole = primaryRole;
-        this.primaryChamp = primaryChamp;
-        this.secondaryRole = secondaryRole;
-        this.secondaryChamp = secondaryChamp;
-        this.targetRole = targetRole;
-        this.memo = memo;
-        this.mic = mic;
-        this.memberId = memberId;
-        this.accountId = accountId;
-    }
 
-    private Duo(QueueType queueType, Lane primaryRole, Lane targetRole, String memo, Boolean mic, Long memberId,
-                Long accountId) {
-        this.queueType = queueType;
-        this.primaryRole = primaryRole;
-        this.targetRole = targetRole;
-        this.memo = memo;
-        this.mic = mic;
-        this.memberId = memberId;
-        this.accountId = accountId;
-    }
 
-    public static Duo quickOf(QueueType queueType, Lane primaryRole, String primaryChamp, Lane secondaryRole,
-                              String secondaryChamp, Lane targetRole, String memo, Boolean mic, Long memberId, Long accountId) {
-        return new Duo(queueType, primaryRole, primaryChamp, secondaryRole, secondaryChamp, targetRole, memo, mic,
-                memberId, accountId);
-    }
-
-    public static Duo rankOf(QueueType queueType, Lane primaryRole, Lane targetRole, String memo, Boolean mic,
-                             Long memberId, Long accountId) {
-        return new Duo(queueType, primaryRole, targetRole, memo, mic, memberId, accountId);
-    }
 
 }

--- a/src/main/java/com/summoner/lolhaeduo/domain/duo/entity/Duo.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/duo/entity/Duo.java
@@ -22,21 +22,22 @@ public class Duo extends Timestamped {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private QueueType queueType;
 
+    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Lane primaryRole;
 
-    @Column(nullable = false)
     private String primaryChamp;
 
     @Enumerated(EnumType.STRING)
     private Lane secondaryRole;
 
-    @Column(nullable = false)
     private String secondaryChamp;
 
+    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Lane targetRole;
 

--- a/src/main/java/com/summoner/lolhaeduo/domain/duo/entity/Duo.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/duo/entity/Duo.java
@@ -45,12 +45,16 @@ public class Duo extends Timestamped {
 
     private Boolean mic;
 
+    @Column(nullable = false)
     private String tier;
 
+    @Column(nullable = false)
     private String rank;
 
+    @Column(nullable = false)
     private int wins;
 
+    @Column(nullable = false)
     private int losses;
 
     private String favoritesChamp;

--- a/src/main/java/com/summoner/lolhaeduo/domain/duo/entity/Kda.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/duo/entity/Kda.java
@@ -1,0 +1,17 @@
+package com.summoner.lolhaeduo.domain.duo.entity;
+
+import jakarta.persistence.Embeddable;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Embeddable
+@Data
+@NoArgsConstructor
+public class Kda {
+
+    private BigDecimal averageKills;
+    private BigDecimal averageAssists;
+    private BigDecimal averageDeaths;
+}


### PR DESCRIPTION
## ✨ 담당 파트
- 롤 듀오 찾기 등록

## 🔎 작업 상세 내용
- Duo 엔티티 설계 변경에 따른 컬럼추가 : tier, rank, wins, losses, favoritesChamp, profileIcon 컬럼 추가 
- Kda 임베디드 클래스 추가 : 최근 경기의 킬, 어시스트, 데스의 평균 값을 저장
- RiotUtil : LegueV4 API 호출해서 리그정보 가져오는 로직 추가, LeagueEntryResponse에 저장
- DTO : 듀오 찾기 등록시 필요한 request, response DTO 추가 

## 🔧 앞으로의 과제
- 설계변경에 따른 비즈니스 로직 추가 예정 : 랭크게임의 티어, 랭크,  승률 추가예정
- 매치정보를 가져오는 로직, 매치정보를 활용한 비즈니스 로직 추가 예정 : 최근선호챔피언, KDA
- 프로필 아이콘 가져오는 로직 추가 예쩡

## ✅ 테스트 코드 작성 및 기능 테스트 여부
- [] 테스트 코드 작성
- [] 기능 테스트 여부

## ➕ 이슈 링크
- #8