### PR TITLE
feat: 데이터 드래곤 (버전, 챔피언, 프로필 아이콘)

### DIFF
--- a/src/main/java/com/summoner/lolhaeduo/client/entity/Champion.java
+++ b/src/main/java/com/summoner/lolhaeduo/client/entity/Champion.java
@@ -1,0 +1,26 @@
+package com.summoner.lolhaeduo.client.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Champion {
+
+    @Id
+    private String id;
+
+    private String name;
+
+    private Champion(String id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public static Champion of(String id, String name) {
+        return new Champion(id, name);
+    }
+}

--- a/src/main/java/com/summoner/lolhaeduo/client/entity/ProfileIcon.java
+++ b/src/main/java/com/summoner/lolhaeduo/client/entity/ProfileIcon.java
@@ -11,13 +11,13 @@ import lombok.NoArgsConstructor;
 public class ProfileIcon {
 
     @Id
-    private Integer id;
+    private int id;
 
-    private ProfileIcon(Integer id) {
+    private ProfileIcon(int id) {
         this.id = id;
     }
 
-    public static ProfileIcon of(Integer id) {
+    public static ProfileIcon of(int id) {
         return new ProfileIcon(id);
     }
 }

--- a/src/main/java/com/summoner/lolhaeduo/client/entity/ProfileIcon.java
+++ b/src/main/java/com/summoner/lolhaeduo/client/entity/ProfileIcon.java
@@ -1,0 +1,23 @@
+package com.summoner.lolhaeduo.client.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class ProfileIcon {
+
+    @Id
+    private Integer id;
+
+    private ProfileIcon(Integer id) {
+        this.id = id;
+    }
+
+    public static ProfileIcon of(Integer id) {
+        return new ProfileIcon(id);
+    }
+}

--- a/src/main/java/com/summoner/lolhaeduo/client/entity/Version.java
+++ b/src/main/java/com/summoner/lolhaeduo/client/entity/Version.java
@@ -1,0 +1,26 @@
+package com.summoner.lolhaeduo.client.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Version {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true)
+    private String versionNumber;
+
+    private Version(String versionNumber) {
+        this.versionNumber = versionNumber;
+    }
+
+    public static Version of(String versionNumber) {
+        return new Version(versionNumber);
+    }
+}

--- a/src/main/java/com/summoner/lolhaeduo/client/repository/ChampionRepository.java
+++ b/src/main/java/com/summoner/lolhaeduo/client/repository/ChampionRepository.java
@@ -1,0 +1,13 @@
+package com.summoner.lolhaeduo.client.repository;
+
+import com.summoner.lolhaeduo.client.entity.Champion;
+import com.summoner.lolhaeduo.client.entity.Version;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Set;
+
+public interface ChampionRepository extends JpaRepository<Champion, Long> {
+    @Query("SELECT c.id FROM Champion c")
+    Set<String> findAllIds();
+}

--- a/src/main/java/com/summoner/lolhaeduo/client/repository/ProfileIconRepository.java
+++ b/src/main/java/com/summoner/lolhaeduo/client/repository/ProfileIconRepository.java
@@ -1,0 +1,8 @@
+package com.summoner.lolhaeduo.client.repository;
+
+import com.summoner.lolhaeduo.client.entity.Champion;
+import com.summoner.lolhaeduo.client.entity.ProfileIcon;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProfileIconRepository extends JpaRepository<ProfileIcon, Long> {
+}

--- a/src/main/java/com/summoner/lolhaeduo/client/repository/VersionRepository.java
+++ b/src/main/java/com/summoner/lolhaeduo/client/repository/VersionRepository.java
@@ -1,0 +1,7 @@
+package com.summoner.lolhaeduo.client.repository;
+
+import com.summoner.lolhaeduo.client.entity.Version;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VersionRepository extends JpaRepository<Version, Long> {
+}

--- a/src/main/java/com/summoner/lolhaeduo/client/riot/DataDragonScheduler.java
+++ b/src/main/java/com/summoner/lolhaeduo/client/riot/DataDragonScheduler.java
@@ -1,0 +1,101 @@
+package com.summoner.lolhaeduo.client.riot;
+
+import com.summoner.lolhaeduo.client.entity.Champion;
+import com.summoner.lolhaeduo.client.entity.ProfileIcon;
+import com.summoner.lolhaeduo.client.entity.Version;
+import com.summoner.lolhaeduo.client.repository.ChampionRepository;
+import com.summoner.lolhaeduo.client.repository.ProfileIconRepository;
+import com.summoner.lolhaeduo.client.repository.VersionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class DataDragonScheduler {
+
+    private final VersionRepository versionRepository;
+    private final ChampionRepository championRepository;
+    private final ProfileIconRepository profileIconRepository;
+    private final RestTemplate restTemplate;
+
+    @Scheduled(cron = "0 0 0 * * MON")  // Update at every monday 00:00
+    public void updateDataDragonInfo() {
+        String latestVersion = fetchLatestVersion();
+        saveVersion(latestVersion);
+        updateChampions(latestVersion);
+        updateProfileIcons(latestVersion);
+    }
+
+    private String fetchLatestVersion() {
+        String url = "https://ddragon.leagueoflegends.com/api/versions.json";
+        ResponseEntity<List<String>> response = restTemplate.exchange(
+                url,
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<List<String>>() {}
+        );
+        return response.getBody().get(0);
+    }
+
+    private void saveVersion(String version) {
+        Version latestVersion = Version.of(version);
+        versionRepository.save(latestVersion);
+    }
+
+    private void updateChampions(String version) {
+        String url = String.format(
+                "https://ddragon.leagueoflegends.com/cdn/%s/data/ko_KR/champion.json",
+                version
+        );
+
+        Map<String, Object> response = restTemplate.getForObject(url, Map.class);
+        Map<String, Object> data = (Map<String, Object>) response.get("data");
+
+        // Delete original data
+        championRepository.deleteAll();
+
+        List<Champion> champions = data.values().stream()
+            .map(champData -> {
+                Map<String, Object> champMap = (Map<String, Object>) champData;
+                return Champion.of(
+                    champMap.get("id").toString(),
+                    champMap.get("name").toString()
+                );
+            })
+            .toList();
+
+        championRepository.saveAll(champions);
+    }
+
+    private void updateProfileIcons(String version) {
+        String url = String.format(
+            "https://ddragon.leagueoflegends.com/cdn/%s/data/ko_KR/profileicon.json",
+            version
+        );
+
+        Map<String, Object> response = restTemplate.getForObject(url, Map.class);
+        Map<String, Object> data = (Map<String, Object>) response.get("data");
+
+        // Delete original data
+        profileIconRepository.deleteAll();
+
+        List<ProfileIcon> icons = data.values().stream()
+            .map(iconData -> {
+                Map<String, Object> iconMap = (Map<String, Object>) iconData;
+                return ProfileIcon.of(
+                        Integer.parseInt(iconMap.get("id").toString())
+                );
+            })
+            .toList();
+
+        profileIconRepository.saveAll(icons);
+    }
+}

--- a/src/test/java/com/summoner/lolhaeduo/client/riot/DataDragonSchedulerTest.java
+++ b/src/test/java/com/summoner/lolhaeduo/client/riot/DataDragonSchedulerTest.java
@@ -1,0 +1,73 @@
+package com.summoner.lolhaeduo.client.riot;
+
+import com.summoner.lolhaeduo.client.entity.Champion;
+import com.summoner.lolhaeduo.client.entity.ProfileIcon;
+import com.summoner.lolhaeduo.client.entity.Version;
+import com.summoner.lolhaeduo.client.repository.ChampionRepository;
+import com.summoner.lolhaeduo.client.repository.ProfileIconRepository;
+import com.summoner.lolhaeduo.client.repository.VersionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+class DataDragonSchedulerTest {
+
+    @Autowired
+    private DataDragonScheduler dataDragonScheduler;
+
+    @Autowired
+    private VersionRepository versionRepository;
+
+    @Autowired
+    private ChampionRepository championRepository;
+
+    @Autowired
+    private ProfileIconRepository profileIconRepository;
+
+    @BeforeEach
+    void setUp() {
+        // starting from empty DB
+        versionRepository.deleteAll();
+        championRepository.deleteAll();
+        profileIconRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("verify if the taken data is not null")
+    void test1() {
+        // execute method
+        dataDragonScheduler.updateDataDragonInfo();
+
+        // verify data : Version
+        List<Version> versions = versionRepository.findAll();
+        assertThat(versions).hasSize(1);
+        String latestVersion = versions.get(0).getVersionNumber();
+        assertThat(latestVersion).isNotBlank();
+
+        // verify data : Champion
+        List<Champion> champions = championRepository.findAll();
+        assertThat(champions).isNotEmpty();
+        Optional<Champion> exampleChampion = champions.stream().findFirst();
+        assertThat(exampleChampion).isPresent();
+        assertThat(exampleChampion.get().getId()).isNotBlank();
+        assertThat(exampleChampion.get().getName()).isNotBlank();
+
+        // verify data : ProfileIcon
+        List<ProfileIcon> icons = profileIconRepository.findAll();
+        assertThat(icons).isNotEmpty();
+        Optional<ProfileIcon> exampleIcon = icons.stream().findFirst();
+        assertThat(exampleIcon).isPresent();
+        assertThat(exampleIcon.get().getId()).isNotNull();
+    }
+}


### PR DESCRIPTION
## ✨ 담당 파트
- datadragon 관련: 버전 업데이트

## 🔎 작업 상세 내용
1주일에 한번, 최신 버전 정보를 업데이트해서 DB에 저장하는 스케쥴러 코드를 만들 예정
라이엇에서 제공하는 데이터 드래곤 정보를 이요해서 현재 최신 버전, 챔피언 목록, 그리고 프로필 아이콘 값을 가져올 수 있음

최신 버전을 가져오는 방법:
1. https://ddragon.leagueoflegends.com/api/versions.json 링크로 이동한다.
2. json 파일의 0번째 인덱스 값을 읽는다.

챔피언 정보를 가져오는 방법:
1. https://ddragon.leagueoflegends.com/cdn/{최신버전넘버링}/data/ko_KR/champion.json 링크로 이동한다.
2. json 파일의 data 항목의 각 챔피언들의 id값을 가져와서 저장한다.

프로필 아이콘 정보를 가져오는 방법:
1. https://ddragon.leagueoflegends.com/cdn/{최신버전넘버링}/data/ko_KR/profileicon.json 링크로 이동한다.
2. json 파일의 data 항목의 각 프로필 아이콘의 id값을 가져와서 저장한다.

## 🔧 앞으로의 과제
- 이 부분은 추가 수정이 없을듯 합니다.

## ✅ 테스트 코드 작성 및 기능 테스트 여부
- [x] 테스트 코드 작성
- [x] 기능 테스트 여부

## ➕ 이슈 링크
- #14