### PR TITLE
fix: Duo entity 수정

### DIFF
--- a/src/main/java/com/summoner/lolhaeduo/domain/duo/entity/Duo.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/duo/entity/Duo.java
@@ -164,6 +164,9 @@ public class Duo extends Timestamped {
         );
     }
 
+    /*
+    // 듀오 찾기 수정이 진행되면, 변경될 수 있는 부분입니다.
+    */
     public void update(QueueType queueType,
                        Lane primaryRole, String primaryChamp,
                        Lane secondaryRole, String secondaryChamp,

--- a/src/main/java/com/summoner/lolhaeduo/domain/duo/entity/Duo.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/duo/entity/Duo.java
@@ -118,13 +118,19 @@ public class Duo extends Timestamped {
                               Long memberId, Long accountId) {
         return new Duo(
                 queueType,
-                primaryRole, primaryChamp,
-                secondaryRole, secondaryChamp,
+                primaryRole,
+                primaryChamp,
+                secondaryRole,
+                secondaryChamp,
                 targetRoles,
-                memo, mic,
-                tier, rank,
-                wins, losses,
-                memberId, accountId
+                memo,
+                mic,
+                tier,
+                rank,
+                wins,
+                losses,
+                memberId,
+                accountId
         );
     }
 
@@ -136,13 +142,19 @@ public class Duo extends Timestamped {
                              Long memberId, Long accountId) {
         return new Duo(
                 queueType,
-                primaryRole, null,
-                null, null,
+                primaryRole,
+                null,
+                null,
+                null,
                 targetRoles,
-                memo, mic,
-                tier, rank,
-                wins, losses,
-                memberId, accountId
+                memo,
+                mic,
+                tier,
+                rank,
+                wins,
+                losses,
+                memberId,
+                accountId
         );
     }
 
@@ -154,13 +166,19 @@ public class Duo extends Timestamped {
                              Long memberId, Long accountId) {
         return new Duo(
                 queueType,
-                primaryRole, null,
-                null, null,
+                primaryRole,
+                null,
+                null,
+                null,
                 targetRoles,
-                memo, mic,
-                tier, rank,
-                wins, losses,
-                memberId, accountId
+                memo,
+                mic,
+                tier,
+                rank,
+                wins,
+                losses,
+                memberId,
+                accountId
         );
     }
 

--- a/src/main/java/com/summoner/lolhaeduo/domain/duo/repository/DuoRepository.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/duo/repository/DuoRepository.java
@@ -1,4 +1,7 @@
 package com.summoner.lolhaeduo.domain.duo.repository;
 
-public class DuoRepository {
+import com.summoner.lolhaeduo.domain.duo.entity.Duo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DuoRepository extends JpaRepository<Duo, Long> {
 }


### PR DESCRIPTION
## ✨ 담당 파트
- Duo entity 수정

## 🔎 작업 상세 내용
### 1. Duo entity 수정
- 하나의 역할군만 선택 가능했던 '선호하는 매칭 역할군'을 여러 역할군으로 선택 가능하게 수정하므로서, 값 타입 컬렉션으로 수정
- 랭크별 정적 팩토리 메서드 분리
- 수정 메서드 추가

### 2. DuoRepository 수정
- DuoRepository 를 JpaRepository 상속받는 인터페이스로 변경
<br>

## 🔧 앞으로의 과제
- 많아용~~
<br>

## ✅ 테스트 코드 작성 및 기능 테스트 여부
- [ ] 테스트 코드 작성
- [ ] 기능 테스트 여부
<br>

## ➕ 이슈 링크
- #18 
