### PR TITLE
feat : 듀오 찾기 등록 (솔로,자유) 추가, JwtUtil 오류수정

### DIFF
--- a/src/main/java/com/summoner/lolhaeduo/common/filter/JwtFilter.java
+++ b/src/main/java/com/summoner/lolhaeduo/common/filter/JwtFilter.java
@@ -45,5 +45,8 @@ public class JwtFilter extends HttpFilter {
         log.info("토큰 = {}", token);
 
         jwtUtil.validateToken(token);
+
+        filterChain.doFilter(httpServletRequest, httpServletResponse);
+
     }
 }

--- a/src/main/java/com/summoner/lolhaeduo/domain/account/repository/AccountRepository.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/account/repository/AccountRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AccountRepository extends JpaRepository<Account, Long>, AccountQuerydslRepository{
     boolean existsByUsername(String username);
+
+    Account findByMemberId(Long memberId);
 }

--- a/src/main/java/com/summoner/lolhaeduo/domain/duo/controller/DuoController.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/duo/controller/DuoController.java
@@ -1,4 +1,29 @@
 package com.summoner.lolhaeduo.domain.duo.controller;
 
+import com.summoner.lolhaeduo.common.annotation.Auth;
+import com.summoner.lolhaeduo.common.dto.AuthMember;
+import com.summoner.lolhaeduo.domain.duo.dto.DuoCreateRequest;
+import com.summoner.lolhaeduo.domain.duo.dto.DuoCreateResponse;
+import com.summoner.lolhaeduo.domain.duo.service.DuoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
 public class DuoController {
+
+    private final DuoService duoService;
+
+    @PostMapping("/duo")
+    public ResponseEntity<DuoCreateResponse> createDuo(@RequestBody DuoCreateRequest createRequest, @Auth AuthMember authMember) {
+
+        DuoCreateResponse duoCreateResponse = duoService.createDuo(createRequest,authMember.getMemberId());
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(duoCreateResponse);
+    }
 }

--- a/src/main/java/com/summoner/lolhaeduo/domain/duo/entity/Duo.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/duo/entity/Duo.java
@@ -10,8 +10,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @Entity
@@ -39,11 +37,8 @@ public class Duo extends Timestamped {
 
     private String secondaryChamp;
 
-    @ElementCollection  // <duo_id, Lane>
-    @CollectionTable(name = "TARGET_ROLE", joinColumns = @JoinColumn(name = "DUO_ID"))
-    @Column
     @Enumerated(EnumType.STRING)
-    private List<Lane> targetRoles = new ArrayList<>();
+    private Lane targetRole;
 
     private String memo;
 
@@ -53,7 +48,7 @@ public class Duo extends Timestamped {
     private String tier;
 
     @Column(nullable = false)
-    private String rank;
+    private String ranks;
 
     @Column(nullable = false)
     private int wins;
@@ -77,31 +72,17 @@ public class Duo extends Timestamped {
     private LocalDateTime deletedAt;
 
     private Duo(QueueType queueType, Lane primaryRole, String primaryChamp, Lane secondaryRole, String secondaryChamp,
-                List<Lane> targetRoles, String memo, Boolean mic, Long memberId, Long accountId) {
+                Lane targetRole, String memo, Boolean mic, String tier, String ranks, int wins, int losses, Long memberId, Long accountId) {
         this.queueType = queueType;
         this.primaryRole = primaryRole;
         this.primaryChamp = primaryChamp;
         this.secondaryRole = secondaryRole;
         this.secondaryChamp = secondaryChamp;
-        this.targetRoles = targetRoles;
-        this.memo = memo;
-        this.mic = mic;
-        this.memberId = memberId;
-        this.accountId = accountId;
-    }
-
-    private Duo(QueueType queueType, Lane primaryRole, String primaryChamp, Lane secondaryRole, String secondaryChamp,
-                List<Lane> targetRoles, String memo, Boolean mic, String tier, String rank, int wins, int losses, Long memberId, Long accountId) {
-        this.queueType = queueType;
-        this.primaryRole = primaryRole;
-        this.primaryChamp = primaryChamp;
-        this.secondaryRole = secondaryRole;
-        this.secondaryChamp = secondaryChamp;
-        this.targetRoles = targetRoles;
+        this.targetRole = targetRole;
         this.memo = memo;
         this.mic = mic;
         this.tier = tier;
-        this.rank = rank;
+        this.ranks = ranks;
         this.wins = wins;
         this.losses = losses;
         this.memberId = memberId;
@@ -111,7 +92,7 @@ public class Duo extends Timestamped {
     public static Duo quickOf(QueueType queueType,
                               Lane primaryRole, String primaryChamp,
                               Lane secondaryRole, String secondaryChamp,
-                              List<Lane> targetRoles,
+                              Lane targetRole,
                               String memo, Boolean mic,
                               String tier, String rank,
                               int wins, int losses, // 최근 20게임 승패
@@ -122,7 +103,7 @@ public class Duo extends Timestamped {
                 primaryChamp,
                 secondaryRole,
                 secondaryChamp,
-                targetRoles,
+                targetRole,
                 memo,
                 mic,
                 tier,
@@ -135,7 +116,7 @@ public class Duo extends Timestamped {
     }
 
     public static Duo soloOf(QueueType queueType,
-                             Lane primaryRole, List<Lane> targetRoles,
+                             Lane primaryRole, Lane targetRole,
                              String memo, Boolean mic,
                              String tier, String rank,
                              int wins, int losses,  // League API 에서 호출한 시즌 승률 (솔로 랭크 = 개인 게임)
@@ -146,7 +127,7 @@ public class Duo extends Timestamped {
                 null,
                 null,
                 null,
-                targetRoles,
+                targetRole,
                 memo,
                 mic,
                 tier,
@@ -158,8 +139,9 @@ public class Duo extends Timestamped {
         );
     }
 
+
     public static Duo flexOf(QueueType queueType,
-                             Lane primaryRole, List<Lane> targetRoles,
+                             Lane primaryRole, Lane targetRole,
                              String memo, Boolean mic,
                              String tier, String rank,
                              int wins, int losses,  // League API 에서 호출한 시즌 승률 (자유 랭크 = 팀 게임)
@@ -170,7 +152,7 @@ public class Duo extends Timestamped {
                 null,
                 null,
                 null,
-                targetRoles,
+                targetRole,
                 memo,
                 mic,
                 tier,
@@ -188,7 +170,7 @@ public class Duo extends Timestamped {
     public void update(QueueType queueType,
                        Lane primaryRole, String primaryChamp,
                        Lane secondaryRole, String secondaryChamp,
-                       List<Lane> targetRoles,
+                       Lane targetRole,
                        String memo, Boolean mic
     ) {
         this.queueType = queueType;
@@ -196,7 +178,7 @@ public class Duo extends Timestamped {
         this.primaryChamp = primaryChamp;
         this.secondaryRole = secondaryRole;
         this.secondaryChamp = secondaryChamp;
-        this.targetRoles = targetRoles;
+        this.targetRole = targetRole;
         this.memo = memo;
         this.mic = mic;
     }

--- a/src/main/java/com/summoner/lolhaeduo/domain/duo/enums/QueueType.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/duo/enums/QueueType.java
@@ -1,5 +1,28 @@
 package com.summoner.lolhaeduo.domain.duo.enums;
 
 public enum QueueType {
-	QUICK, SOLO, FLEX
-}
+	// QUICK 은 어떤 값으로 넘겨주는 찾아야함
+	QUICK("QUICK"),
+	SOLO("RANKED_SOLO_5x5"),
+	FLEX("RANKED_FLEX_SR");
+
+	private final String riotQueueType;
+
+	QueueType(String riotQueueType) {
+		this.riotQueueType = riotQueueType;
+	}
+
+	public String getRiotQueueType() {
+		return riotQueueType;
+	}
+
+	public static QueueType fromRiotQueueType(String riotQueueType) {
+		for (QueueType type : values()) {
+			if (type.riotQueueType.equalsIgnoreCase(riotQueueType)) {
+				return type;
+			}
+		}
+			throw new IllegalArgumentException("Unknown QueueType: " + riotQueueType);
+		}
+	}
+

--- a/src/main/java/com/summoner/lolhaeduo/domain/duo/service/DuoService.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/duo/service/DuoService.java
@@ -1,7 +1,103 @@
 package com.summoner.lolhaeduo.domain.duo.service;
 
+import com.summoner.lolhaeduo.client.dto.LeagueEntryResponse;
+import com.summoner.lolhaeduo.client.riot.RiotClient;
+import com.summoner.lolhaeduo.domain.account.entity.Account;
+import com.summoner.lolhaeduo.domain.account.repository.AccountRepository;
+import com.summoner.lolhaeduo.domain.duo.dto.DuoCreateRequest;
+import com.summoner.lolhaeduo.domain.duo.dto.DuoCreateResponse;
+import com.summoner.lolhaeduo.domain.duo.entity.Duo;
+import com.summoner.lolhaeduo.domain.duo.enums.QueueType;
+import com.summoner.lolhaeduo.domain.duo.repository.DuoRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
+@RequiredArgsConstructor
 public class DuoService {
+
+    private final DuoRepository duoRepository;
+    private final AccountRepository accountRepository;
+    private final RiotClient riotClient;
+
+    public DuoCreateResponse createDuo(DuoCreateRequest request, Long memberId) {
+        Account linkedAccount  = accountRepository.findByMemberId(memberId);
+        Long linkedAccountId = linkedAccount.getId();
+
+        List<LeagueEntryResponse> rankInfo = getRankInfo(linkedAccount);
+
+        QueueType queueType = QueueType.valueOf(request.getQueueType().toString());
+        Duo duo;
+        switch (queueType) {
+//            case QUICK -> duo = Duo.quickOf(
+//                    request.getQueueType(),
+//                    request.getPrimaryRole(),
+//                    request.getPrimaryChamp(),
+//                    request.getSecondaryRole(),
+//                    request.getSecondaryChamp(),
+//                    targetRoles,
+//                    request.getMemo(),
+//                    request.getMic(),
+//                    memberId,
+//                    linkedAccountId
+//            );
+            case SOLO -> {
+                LeagueEntryResponse selectedRankInfo = rankInfo.stream()
+                        .filter(info -> QueueType.fromRiotQueueType(info.getQueueType()) == queueType)
+                        .findFirst()
+                        .orElseThrow(() -> new IllegalArgumentException("해당 큐 타입에 대한 랭크 정보를 찾을 수 없습니다."));
+
+                duo = Duo.soloOf(
+                        request.getQueueType(),
+                        request.getPrimaryRole(),
+                        request.getTargetRole(),
+                        request.getMemo(),
+                        request.getMic(),
+                        selectedRankInfo.getTier(),
+                        selectedRankInfo.getRank(),
+                        selectedRankInfo.getWins(),
+                        selectedRankInfo.getLosses(),
+                        memberId,
+                        linkedAccountId
+                );
+            }
+
+            case FLEX -> {
+                LeagueEntryResponse selectedRankInfo = rankInfo.stream()
+                        .filter(info -> QueueType.fromRiotQueueType(info.getQueueType()) == queueType)
+                        .findFirst()
+                        .orElseThrow(() -> new IllegalArgumentException("해당 큐 타입에 대한 랭크 정보를 찾을 수 없습니다."));
+
+                duo = Duo.flexOf(
+                        request.getQueueType(),
+                        request.getPrimaryRole(),
+                        request.getTargetRole(),
+                        request.getMemo(),
+                        request.getMic(),
+                        selectedRankInfo.getTier(),
+                        selectedRankInfo.getRank(),
+                        selectedRankInfo.getWins(),
+                        selectedRankInfo.getLosses(),
+                        memberId,
+                        linkedAccountId
+                );
+            }
+
+            default -> throw new IllegalArgumentException("Queue Type 잘못됨");
+        }
+        duoRepository.save(duo);
+        return new DuoCreateResponse(duo);
+    }
+
+    // 랭크 티어 가져오기
+    private List<LeagueEntryResponse> getRankInfo(Account linkedAccount) {
+        String encryptedSummonerId = linkedAccount.getAccountDetail().getEncryptedSummonerId();
+
+        return riotClient.extractLeagueInfo(
+                encryptedSummonerId,
+                linkedAccount.getServer()
+        );
+    }
 }

--- a/src/test/java/com/summoner/lolhaeduo/client/riot/RiotClientTest.java
+++ b/src/test/java/com/summoner/lolhaeduo/client/riot/RiotClientTest.java
@@ -1,6 +1,7 @@
 package com.summoner.lolhaeduo.client.riot;
 
 import com.summoner.lolhaeduo.client.dto.FormattedMatchResponse;
+import com.summoner.lolhaeduo.client.dto.LeagueEntryResponse;
 import com.summoner.lolhaeduo.client.dto.PuuidResponse;
 import com.summoner.lolhaeduo.client.dto.SummonerResponse;
 import com.summoner.lolhaeduo.domain.account.enums.AccountRegion;
@@ -51,6 +52,21 @@ class RiotClientTest {
 
         // then
         assertThat(response).isNotNull();
+    }
+
+    @Test
+    @DisplayName("Extract LeagueInfo using summonerId: SUCCESS")
+    void test3() {
+        // given
+        String summonerId = "tjEbbL2gjCFL4BTeV-43s2wEzfwTxf5_Ajt6AIRR3_GWzbTcqtW4Rwk2uw";
+        AccountServer server = AccountServer.KR;
+
+        // when
+        List<LeagueEntryResponse> response = riotClient.extractLeagueInfo(summonerId, server);
+
+        // then
+        assertThat(response).isNotNull();
+
     }
 
     @Test


### PR DESCRIPTION
## ✨ 담당 파트
- 롤 듀오 찾기 등록

## 🔎 작업 상세 내용
- 듀오 찾기 기능 추가 : SOLO, FLEX 랭크일 경우만 등록 -> 추후 QUICK 듀오 등록 기능 추가 예정
- RiotClient : extractLeagueInfo 메서드의 반환타입 List로 변경 -> 리그정보는 SOLO, FLEX 두가지 경우의 리스트로 반환됨
- JwtFilter : 마지막 로직에서 dofilter 누락된 부분 추가 
- Duo 엔티티 : Rank 필드 오류로 ranks로 필드명 변경
- targetRole 타입변경 : List<Lane> -> Lane 

## 🔧 앞으로의 과제
- 빠른 대전 듀오 등록 구현 예정
- targetRole 다중 선택 기능 고려 예정
- Duo 등록시, 승률 계산 및 KDA, 소환사아이콘 가져오는 로직 추가 예정 

## ✅ 테스트 코드 작성 및 기능 테스트 여부
- [] 테스트 코드 작성
- [] 기능 테스트 여부

## ➕ 이슈 링크
- #21 