### PR TITLE
feat: 듀오 찾기 수정

### DIFF
--- a/src/main/java/com/summoner/lolhaeduo/domain/duo/controller/DuoController.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/duo/controller/DuoController.java
@@ -4,15 +4,19 @@ import com.summoner.lolhaeduo.common.annotation.Auth;
 import com.summoner.lolhaeduo.common.dto.AuthMember;
 import com.summoner.lolhaeduo.domain.duo.dto.DuoCreateRequest;
 import com.summoner.lolhaeduo.domain.duo.dto.DuoCreateResponse;
+import com.summoner.lolhaeduo.domain.duo.dto.DuoUpdateRequest;
+import com.summoner.lolhaeduo.domain.duo.dto.DuoUpdateResponse;
 import com.summoner.lolhaeduo.domain.duo.service.DuoService;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
+@RequestMapping("/duo")
 @RequiredArgsConstructor
 public class DuoController {
 
@@ -25,5 +29,20 @@ public class DuoController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(duoCreateResponse);
+    }
+
+    @PutMapping("/{duoId}")
+    public ResponseEntity<DuoUpdateResponse> update(
+            @Auth AuthMember authMember,
+            @PathVariable Long duoId,
+            @Valid @RequestBody DuoUpdateRequest duoUpdateRequest) {
+        if (!duoUpdateRequest.isFlexQueueTypeValid()) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY);
+        }
+        Long memberId = authMember.getMemberId();
+        DuoUpdateResponse response = duoService.update(memberId, duoId, duoUpdateRequest);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(response);
     }
 }

--- a/src/main/java/com/summoner/lolhaeduo/domain/duo/dto/DuoUpdateRequest.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/duo/dto/DuoUpdateRequest.java
@@ -31,9 +31,9 @@ public class DuoUpdateRequest {
     private Boolean mic;            // 마이크
 
     // 큐 타입에 따른 유효성 검사
-    @AssertTrue(message = "큐 타입이 빠른 대전인 경우, primaryChamp 와 secondaryRole, secondaryChamp 는 NULL 이어야 합니다.")
-    public boolean isFlexQueueTypeValid() {
-        if (queueType == QueueType.FLEX) {
+    @AssertTrue(message = "큐 타입이 빠른 대전인 경우, primaryChamp 와 secondaryRole, secondaryChamp 는 NULL 이 아니어야 합니다.")
+    public boolean isQuickQueueTypeValid() {
+        if (queueType != QueueType.QUICK) {
             return primaryChamp == null && secondaryRole == null && secondaryChamp == null;
         }
         return true;

--- a/src/main/java/com/summoner/lolhaeduo/domain/duo/dto/DuoUpdateRequest.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/duo/dto/DuoUpdateRequest.java
@@ -1,0 +1,56 @@
+package com.summoner.lolhaeduo.domain.duo.dto;
+
+import com.summoner.lolhaeduo.domain.duo.enums.Lane;
+import com.summoner.lolhaeduo.domain.duo.enums.QueueType;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class DuoUpdateRequest {
+    @NotNull
+    private QueueType queueType;    // 큐 타입
+
+    @NotNull
+    private Lane primaryRole;       // 주 역할군
+
+    private String primaryChamp;    // 주 역할군의 선호 챔피언
+
+    private Lane secondaryRole;     // 부 역할군
+
+    private String secondaryChamp;  // 부 역할군의 선호 챔피언
+
+    @NotNull
+    private Lane targetRole;  // 선호하는 매칭 역할군
+
+    @Size(max = 50, message = "메모는 최대 50자까지만 작성 가능합니다.")
+    private String memo;            // 메모
+
+    @NotNull
+    private Boolean mic;            // 마이크
+
+    // 큐 타입에 따른 유효성 검사
+    @AssertTrue(message = "큐 타입이 빠른 대전인 경우, primaryChamp 와 secondaryRole, secondaryChamp 는 NULL 이어야 합니다.")
+    public boolean isFlexQueueTypeValid() {
+        if (queueType == QueueType.FLEX) {
+            return primaryChamp == null && secondaryRole == null && secondaryChamp == null;
+        }
+        return true;
+    }
+
+    private DuoUpdateRequest(QueueType queueType, Lane primaryRole, String primaryChamp, Lane secondaryRole, String secondaryChamp, Lane targetRole, String memo, Boolean mic) {
+        this.queueType = queueType;
+        this.primaryRole = primaryRole;
+        this.primaryChamp = primaryChamp;
+        this.secondaryRole = secondaryRole;
+        this.secondaryChamp = secondaryChamp;
+        this.targetRole = targetRole;
+        this.memo = memo;
+        this.mic = mic;
+    }
+
+    public static DuoUpdateRequest of(QueueType queueType, Lane primaryRole, String primaryChamp, Lane secondaryRole, String secondaryChamp, Lane targetRole, String memo, Boolean mic) {
+        return new DuoUpdateRequest(queueType, primaryRole, primaryChamp, secondaryRole, secondaryChamp, targetRole, memo, mic);
+    }
+}

--- a/src/main/java/com/summoner/lolhaeduo/domain/duo/dto/DuoUpdateResponse.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/duo/dto/DuoUpdateResponse.java
@@ -1,0 +1,84 @@
+package com.summoner.lolhaeduo.domain.duo.dto;
+
+import com.summoner.lolhaeduo.domain.duo.entity.Duo;
+import com.summoner.lolhaeduo.domain.duo.entity.Kda;
+import com.summoner.lolhaeduo.domain.duo.enums.Lane;
+import com.summoner.lolhaeduo.domain.duo.enums.QueueType;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class DuoUpdateResponse {
+    private Long duoId;                 // 듀오 찾기의 ID
+    private QueueType queueType;        // 큐 타입
+    private Lane primaryRole;           // 주 역할군
+    private String primaryChamp;        // 주 역할군의 선호 챔피언
+    private Lane secondaryRole;         // 부 역할군
+    private String secondaryChamp;      // 부 역할군의 선호 챔피언
+    private Lane targetRole;            // 선호하는 매칭 역할군
+    private String memo;                // 메모
+    private Boolean mic;                // 마이크
+    private String tier;                // 신청한 유저의 티어
+    private String ranks;               // 신청한 유저의 랭크
+    private int wins;
+    private int losses;
+    private String favoritesChamp;
+    private String profileIcon;
+    private Kda kda;
+    private Long memberId;              // 신청한 유저의 ID
+    private Long accountId;             // 신청한 유저의 연동 계정 ID
+    private LocalDateTime createAt;     // 듀오 찾기 생성 일자
+    private LocalDateTime modifiedAt;   // 듀오 찾기 수정 일자
+
+    public DuoUpdateResponse(Long duoId, QueueType queueType, Lane primaryRole, String primaryChamp,
+                             Lane secondaryRole, String secondaryChamp, Lane targetRole, String memo, Boolean mic,
+                             String tier, String ranks, int wins, int losses, String favoritesChamp, String profileIcon,
+                             Kda kda, Long memberId, Long accountId, LocalDateTime createAt, LocalDateTime modifiedAt) {
+        this.duoId = duoId;
+        this.queueType = queueType;
+        this.primaryRole = primaryRole;
+        this.primaryChamp = primaryChamp;
+        this.secondaryRole = secondaryRole;
+        this.secondaryChamp = secondaryChamp;
+        this.targetRole = targetRole;
+        this.memo = memo;
+        this.mic = mic;
+        this.tier = tier;
+        this.ranks = ranks;
+        this.wins = wins;
+        this.losses = losses;
+        this.favoritesChamp = favoritesChamp;
+        this.profileIcon = profileIcon;
+        this.kda = kda;
+        this.memberId = memberId;
+        this.accountId = accountId;
+        this.createAt = createAt;
+        this.modifiedAt = modifiedAt;
+    }
+
+    public static DuoUpdateResponse from(Duo duo) {
+        return new DuoUpdateResponse(
+                duo.getId(),
+                duo.getQueueType(),
+                duo.getPrimaryRole(),
+                duo.getPrimaryChamp(),
+                duo.getSecondaryRole(),
+                duo.getSecondaryChamp(),
+                duo.getTargetRole(),
+                duo.getMemo(),
+                duo.getMic(),
+                duo.getTier(),
+                duo.getRanks(),
+                duo.getWins(),
+                duo.getLosses(),
+                duo.getFavoritesChamp(),
+                duo.getProfileIcon(),
+                duo.getKda(),
+                duo.getMemberId(),
+                duo.getAccountId(),
+                duo.getCreatedAt(),
+                duo.getModifiedAt()
+        );
+    }
+}

--- a/src/main/java/com/summoner/lolhaeduo/domain/duo/dto/RecordResponse.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/duo/dto/RecordResponse.java
@@ -1,0 +1,30 @@
+package com.summoner.lolhaeduo.domain.duo.dto;
+
+import com.summoner.lolhaeduo.domain.duo.entity.Kda;
+import lombok.Getter;
+
+@Getter
+public class RecordResponse {
+
+    private int wins;       // 승리 횟수
+    private int losses;     // 패배 횟수
+    private int kills;      // 총 kill 횟수
+    private int deaths;     // 총 death 횟수
+    private int assists;    // 총 assist 횟수
+    private int playCounts; // 게임 플레이 횟수
+    private Kda kda;        // 각각의 평균 K/D/A를 담고 있는 Kda
+
+    private RecordResponse(int wins, int losses, int kills, int deaths, int assists, int playCounts, Kda kda) {
+        this.wins = wins;
+        this.losses = losses;
+        this.kills = kills;
+        this.deaths = deaths;
+        this.assists = assists;
+        this.playCounts = playCounts;
+        this.kda = kda;
+    }
+
+    public static RecordResponse of(int wins, int losses, int kills, int deaths, int assists, int playCounts, Kda kda) {
+        return new RecordResponse(wins, losses, kills, deaths, assists, playCounts, kda);
+    }
+}

--- a/src/main/java/com/summoner/lolhaeduo/domain/duo/entity/Duo.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/duo/entity/Duo.java
@@ -96,7 +96,7 @@ public class Duo extends Timestamped {
                               Lane secondaryRole, String secondaryChamp,
                               Lane targetRole,
                               String memo, Boolean mic,
-                              String tier, String rank,
+                              String tier, String ranks,
                               int wins, int losses, // 최근 20게임 승패
                               String profileIcon,
                               Long memberId, Long accountId) {
@@ -110,7 +110,7 @@ public class Duo extends Timestamped {
                 memo,
                 mic,
                 tier,
-                rank,
+                ranks,
                 wins,
                 losses,
                 profileIcon,
@@ -122,7 +122,7 @@ public class Duo extends Timestamped {
     public static Duo soloOf(QueueType queueType,
                              Lane primaryRole, Lane targetRole,
                              String memo, Boolean mic,
-                             String tier, String rank,
+                             String tier, String ranks,
                              int wins, int losses,  // League API 에서 호출한 시즌 승률 (솔로 랭크 = 개인 게임)
                              String profileIcon,
                              Long memberId, Long accountId) {
@@ -136,7 +136,7 @@ public class Duo extends Timestamped {
                 memo,
                 mic,
                 tier,
-                rank,
+                ranks,
                 wins,
                 losses,
                 profileIcon,
@@ -145,11 +145,10 @@ public class Duo extends Timestamped {
         );
     }
 
-
     public static Duo flexOf(QueueType queueType,
                              Lane primaryRole, Lane targetRole,
                              String memo, Boolean mic,
-                             String tier, String rank,
+                             String tier, String ranks,
                              int wins, int losses,  // League API 에서 호출한 시즌 승률 (자유 랭크 = 팀 게임)
                              String profileIcon,
                              Long memberId, Long accountId) {
@@ -163,7 +162,7 @@ public class Duo extends Timestamped {
                 memo,
                 mic,
                 tier,
-                rank,
+                ranks,
                 wins,
                 losses,
                 profileIcon,
@@ -176,10 +175,16 @@ public class Duo extends Timestamped {
     // 듀오 찾기 수정이 진행되면, 변경될 수 있는 부분입니다.
     */
     public void update(QueueType queueType,
-                       Lane primaryRole, String primaryChamp,
-                       Lane secondaryRole, String secondaryChamp,
+                       Lane primaryRole,
+                       String primaryChamp,
+                       Lane secondaryRole,
+                       String secondaryChamp,
                        Lane targetRole,
-                       String memo, Boolean mic
+                       String memo,
+                       Boolean mic,
+                       int wins,
+                       int losses,
+                       Kda kda
     ) {
         this.queueType = queueType;
         this.primaryRole = primaryRole;
@@ -189,6 +194,10 @@ public class Duo extends Timestamped {
         this.targetRole = targetRole;
         this.memo = memo;
         this.mic = mic;
+        this.wins = wins;
+        this.losses = losses;
+//        this.favoritesChamp = favoritesChamp;
+        this.kda = kda;
     }
 
     public int calculateWinRate(int wins, int losses) {

--- a/src/main/java/com/summoner/lolhaeduo/domain/duo/entity/Kda.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/duo/entity/Kda.java
@@ -14,4 +14,14 @@ public class Kda {
     private BigDecimal averageKills;
     private BigDecimal averageAssists;
     private BigDecimal averageDeaths;
+
+    private Kda(BigDecimal averageKills, BigDecimal averageAssists, BigDecimal averageDeaths) {
+        this.averageKills = averageKills;
+        this.averageAssists = averageAssists;
+        this.averageDeaths = averageDeaths;
+    }
+
+    public static Kda of(BigDecimal averageKills, BigDecimal averageAssists, BigDecimal averageDeaths) {
+        return new Kda(averageKills, averageAssists, averageDeaths);
+    }
 }

--- a/src/main/java/com/summoner/lolhaeduo/domain/duo/service/DuoService.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/duo/service/DuoService.java
@@ -149,10 +149,6 @@ public class DuoService {
 
         Long duoAccountId = duo.getAccountId();
         Account duoLinkedAccount = accountRepository.findById(duoAccountId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 롤 계정입니다."));
-//        if (!duoLinkedAccount.getMemberId().equals(memberId)) {
-//            throw new IllegalStateException("듀오 신청자의 롤 계정이 아닙니다.");
-//        }
-//        // 중복되는 검증 로직인 듯 합니다.
 
         // todo
         //  - 삭제된 롤 계정인지 확인 -> RSO 연동 후 진행
@@ -188,8 +184,9 @@ public class DuoService {
         int kills = 0;
         int deaths = 0;
         int assists = 0;
+        int daysBefore = 30;
 
-        long startTime = calculateStartTime();  // 빠른 대전일 때, 조회할 기간의 시작 시점; 한 달(30일) 전
+        long startTime = calculateStartTime(daysBefore);    // 빠른 대전일 때, 조회할 기간의 시작 시점; 한 달(30일) 전
         Long endTime = null;        // 빠른 대전일 때, 조회할 기간의 종료 시점 (현재라 설정 안 함)
         Integer queue = 490;        // 빠른 대전의 specific queue id; 490
         String type = "normal";     // 빠른 대전의 type; normal
@@ -259,13 +256,13 @@ public class DuoService {
         return RecordResponse.of(wins, losses, kills, deaths, assists, playCounts, kda);
     }
 
-    // 현재로부터 한 달(30일) 전 Epoch timestamp
-    public long calculateStartTime() {
+    // 현재로부터 days일 전 Epoch timestamp 계산 메서드
+    public long calculateStartTime(int days) {
         // 현재 시간
         Instant now = Instant.now();
 
         // 30일 전 계산
-        Instant thirtyDaysAgo = now.minus(30, ChronoUnit.DAYS);
+        Instant thirtyDaysAgo = now.minus(days, ChronoUnit.DAYS);
 
         // Epoch Time 으로 변환
         long epochTime = thirtyDaysAgo.getEpochSecond();

--- a/src/main/java/com/summoner/lolhaeduo/domain/duo/service/DuoService.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/duo/service/DuoService.java
@@ -1,28 +1,39 @@
 package com.summoner.lolhaeduo.domain.duo.service;
 
+import com.summoner.lolhaeduo.client.dto.FormattedMatchResponse;
 import com.summoner.lolhaeduo.client.dto.LeagueEntryResponse;
-
-import com.summoner.lolhaeduo.client.dto.PuuidResponse;
 import com.summoner.lolhaeduo.client.dto.SummonerResponse;
 import com.summoner.lolhaeduo.client.entity.Version;
 import com.summoner.lolhaeduo.client.repository.VersionRepository;
-
 import com.summoner.lolhaeduo.client.riot.RiotClient;
 import com.summoner.lolhaeduo.domain.account.entity.Account;
+import com.summoner.lolhaeduo.domain.account.enums.AccountRegion;
 import com.summoner.lolhaeduo.domain.account.repository.AccountRepository;
-import com.summoner.lolhaeduo.domain.duo.dto.DuoCreateRequest;
-import com.summoner.lolhaeduo.domain.duo.dto.DuoCreateResponse;
+import com.summoner.lolhaeduo.domain.duo.dto.*;
+import com.summoner.lolhaeduo.domain.duo.dto.DuoUpdateRequest;
 import com.summoner.lolhaeduo.domain.duo.entity.Duo;
+import com.summoner.lolhaeduo.domain.duo.entity.Kda;
 import com.summoner.lolhaeduo.domain.duo.enums.QueueType;
 import com.summoner.lolhaeduo.domain.duo.repository.DuoRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class DuoService {
+
     private final DuoRepository duoRepository;
     private final AccountRepository accountRepository;
     private final VersionRepository versionRepository;
@@ -30,7 +41,7 @@ public class DuoService {
 
     public DuoCreateResponse createDuo(DuoCreateRequest request, Long memberId) {
 
-        Account linkedAccount  = accountRepository.findByMemberId(memberId);
+        Account linkedAccount = accountRepository.findByMemberId(memberId);
         Long linkedAccountId = linkedAccount.getId();
 
         String profileIconUrl = getProfileIconUrl(linkedAccount);
@@ -70,11 +81,10 @@ public class DuoService {
                         memberId,
                         linkedAccountId
                 );
-
             }
 
             case FLEX -> {
-              
+
                 duo = Duo.flexOf(
                         request.getQueueType(),
                         request.getPrimaryRole(),
@@ -90,6 +100,7 @@ public class DuoService {
                         linkedAccountId
                 );
             }
+
             default -> throw new IllegalArgumentException("Queue Type 잘못됨");
         }
         duoRepository.save(duo);
@@ -112,6 +123,7 @@ public class DuoService {
                 latestVersion, accountProfileIconId
         );
     }
+
     // todo 게임버전 api로 변경하면 로직 변경해야함
     private String getLatestVersion() {
         Version latestVersion = versionRepository.findLatestVersion();
@@ -123,5 +135,142 @@ public class DuoService {
                 .filter(info -> QueueType.fromRiotQueueType(info.getQueueType()) == queueType)
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("해당 큐 타입에 대한 랭크 정보를 찾을 수 없습니다."));
+    }
+
+    @Transactional
+    public DuoUpdateResponse update(Long memberId, Long duoId, DuoUpdateRequest updateRequest) {
+        Duo duo = duoRepository.findById(duoId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 듀오 찾기 글입니다."));
+        if (duo.getDeletedAt() != null) {
+            throw new IllegalStateException("삭제된 듀오 찾기 글 입니다.");
+        }
+        if (!duo.getMemberId().equals(memberId)) {
+            throw new IllegalStateException("듀오 신청자가 아닙니다.");
+        }
+
+        Long duoAccountId = duo.getAccountId();
+        Account duoLinkedAccount = accountRepository.findById(duoAccountId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 롤 계정입니다."));
+//        if (!duoLinkedAccount.getMemberId().equals(memberId)) {
+//            throw new IllegalStateException("듀오 신청자의 롤 계정이 아닙니다.");
+//        }
+//        // 중복되는 검증 로직인 듯 합니다.
+
+        // todo
+        //  - 삭제된 롤 계정인지 확인 -> RSO 연동 후 진행
+
+        QueueType queueType = updateRequest.getQueueType();
+        RecordResponse recordResponse = null;
+
+        // 빠른 대전일 때
+        if (queueType == QueueType.QUICK) {
+            recordResponse = callQuickRecord(duoLinkedAccount);
+        }
+
+        duo.update(
+                queueType,
+                updateRequest.getPrimaryRole(),
+                updateRequest.getPrimaryChamp(),
+                updateRequest.getSecondaryRole(),
+                updateRequest.getSecondaryChamp(),
+                updateRequest.getTargetRole(),
+                updateRequest.getMemo(),
+                updateRequest.getMic(),
+                recordResponse.getWins(),
+                recordResponse.getLosses(),
+                recordResponse.getKda()
+        );
+
+        return DuoUpdateResponse.from(duo);
+    }
+
+    public RecordResponse callQuickRecord(Account duoLinkedAccount) {
+        int wins = 0;
+        int losses = 0;
+        int kills = 0;
+        int deaths = 0;
+        int assists = 0;
+
+        long startTime = calculateStartTime();  // 빠른 대전일 때, 조회할 기간의 시작 시점; 한 달(30일) 전
+        Long endTime = null;        // 빠른 대전일 때, 조회할 기간의 종료 시점 (현재라 설정 안 함)
+        Integer queue = 490;        // 빠른 대전의 specific queue id; 490
+        String type = "normal";     // 빠른 대전의 type; normal
+
+        int start = 0;              // 시작 인덱스
+        int count = 20;             // 한 번에 읽어 올 match id의 개수
+
+        AccountRegion region = duoLinkedAccount.getRegion();
+        String puuid = duoLinkedAccount.getAccountDetail().getPuuid();
+
+        // 한 달간 플레이한 최대 20판의 빠른 대전 id
+        List<String> matchIds = riotClient.extractMatchIds(startTime, endTime, queue, type, start, count, region, puuid);
+
+        String summonerName = duoLinkedAccount.getSummonerName();
+        String tagLine = duoLinkedAccount.getTagLine();
+
+        // 한 달간 최대 20판의 플레이한 빠른 대전의
+        // 챔피언 플레이 수
+        // <championName, playingCounts>
+        // <챔피언 이름, 챔피언 플레이 수>
+        Map<String, Integer> playingChampionCount = new HashMap<>();
+
+        List<FormattedMatchResponse> matchDetails = new ArrayList<>();
+        for (String matchId : matchIds) {
+            FormattedMatchResponse matchDetail = riotClient.getMatchDetails(matchId, summonerName, tagLine, region);
+
+            // 승패 계산
+            if (matchDetail.isWin()) {
+                wins++;
+            } else {
+                losses++;
+            }
+
+            // K/D/A
+            kills += matchDetail.getKills();
+            deaths += matchDetail.getDeaths();
+            assists += matchDetail.getAssists();
+
+            // 챔피언별 플레이 수
+            playingChampionCount.put(matchDetail.getChampionName(),
+                    playingChampionCount.getOrDefault(matchDetail.getChampionName(), 0) + 1);
+            // TOP 3 챔피언
+            List<Map.Entry<String, Integer>> top3Champions = playingChampionCount.entrySet().stream()
+                    .sorted((e1, e2) -> e2.getValue().compareTo(e1.getValue()))
+                    .limit(3)
+                    .toList();
+
+            matchDetails.add(matchDetail);
+        }
+        // todo
+        //  - TOP 3 챔피언 어떻게 반환할 건지 정한 후, return
+
+        int playCounts = matchDetails.size();
+        // KDA 평균 계산
+        BigDecimal totalPlayCounts = BigDecimal.valueOf(playCounts);
+        BigDecimal averageKills = matchDetails.isEmpty()
+                ? BigDecimal.ZERO
+                : BigDecimal.valueOf(kills).divide(totalPlayCounts, 2, RoundingMode.HALF_UP);
+        BigDecimal averageDeaths = matchDetails.isEmpty()
+                ? BigDecimal.ZERO
+                : BigDecimal.valueOf(deaths).divide(totalPlayCounts, 2, RoundingMode.HALF_UP);
+        BigDecimal averageAssists = matchDetails.isEmpty()
+                ? BigDecimal.ZERO
+                : BigDecimal.valueOf(assists).divide(totalPlayCounts, 2, RoundingMode.HALF_UP);
+        Kda kda = Kda.of(averageKills, averageDeaths, averageAssists);
+
+        return RecordResponse.of(wins, losses, kills, deaths, assists, playCounts, kda);
+    }
+
+    // 현재로부터 한 달(30일) 전 Epoch timestamp
+    public long calculateStartTime() {
+        // 현재 시간
+        Instant now = Instant.now();
+
+        // 30일 전 계산
+        Instant thirtyDaysAgo = now.minus(30, ChronoUnit.DAYS);
+
+        // Epoch Time 으로 변환
+        long epochTime = thirtyDaysAgo.getEpochSecond();
+        log.info("30일 전 Epoch Time {}", epochTime);
+
+        return epochTime;
     }
 }

--- a/src/test/java/com/summoner/lolhaeduo/domain/duo/dto/DuoUpdateRequestTest.java
+++ b/src/test/java/com/summoner/lolhaeduo/domain/duo/dto/DuoUpdateRequestTest.java
@@ -1,0 +1,74 @@
+package com.summoner.lolhaeduo.domain.duo.dto;
+
+import com.summoner.lolhaeduo.domain.duo.enums.Lane;
+import com.summoner.lolhaeduo.domain.duo.enums.QueueType;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DuoUpdateRequestTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        // Validator 초기화
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    @DisplayName("유효한 DuoUpdateRequest 가 검증을 통과한다.")
+    void validDuoUpdateRequest() {
+        // Given
+        DuoUpdateRequest request = DuoUpdateRequest.of(
+                QueueType.QUICK,
+                Lane.TOP,
+                "Teemo",
+                Lane.JUNGLE,
+                "Shaco",
+                Lane.MID,
+                "즐겜합시다",
+                true
+        );
+
+        // When
+        Set<ConstraintViolation<DuoUpdateRequest>> violations = validator.validate(request);
+
+        // Then
+        assertTrue(violations.isEmpty(), "유효성 검증이 통과해야 합니다.");
+    }
+
+    @Test
+    @DisplayName("Flex 큐 타입에서 조건 위반 시 검증에 실패한다.")
+    void flexQueueTypeValidationFails() {
+        // Given
+        DuoUpdateRequest request = DuoUpdateRequest.of(
+                QueueType.FLEX,
+                Lane.TOP,
+                "Teemo",
+                Lane.JUNGLE,
+                "Shaco",
+                Lane.MID,
+                "즐겜합시다",
+                true
+        );
+
+        // When
+        Set<ConstraintViolation<DuoUpdateRequest>> violations = validator.validate(request);
+
+        // Then
+        assertEquals(1, violations.size(), "검증 위반이 1건이어야 합니다.");
+        assertEquals("큐 타입이 빠른 대전인 경우, primaryChamp 와 secondaryRole, secondaryChamp 는 NULL 이어야 합니다.",
+                violations.iterator().next().getMessage());
+    }
+}


### PR DESCRIPTION
## ✨ 담당 파트
- 듀오 찾기 수정
<br>

## 🔎 작업 상세 내용
### 1. Duo entity 수정
- 듀오 찾기 수정에 따른 Duo 엔티티 수정
- DB의 예약어인 rank 를 ranks 로 수정

### 2. DuoUpdateRequest 추가
- 듀오 찾기 수정의 Request DTO

### 3. DuoController 수정
- 듀오 찾기 수정 메서드 update() 추가

### 4. Kda entity 에 private 생성자 및 정적 팩토리 메서드 추가
- private 생성자
- 정적 팩토리 메서드 of

### 5. Riot API 를 이용하여, 반환받는 전적 기록 RecordResponse 추가
- wins: 승리 횟수
- losses: 패배 횟수
- kills: 총 kill 횟수
- deaths: 총 death 횟수
- assists: 총 assist 횟수
- playCounts: 게임 플레이 횟수
- kda: 각각의 평균 K/D/A를 담고 있는 Kda

### 6. DuoUpdateResponse 추가
- 듀오 찾기 수정 후 반환하는 DTO
<br>

## 🔧 앞으로의 과제
- 당장 추가될 부분은 코드의 todo에 적어놨습니다

## ✅ 테스트 코드 작성 및 기능 테스트 여부
- [ ] 테스트 코드 작성
- [ ] 기능 테스트 여부
<br>

## ➕ 이슈 링크
- #13 
