### PR TITLE
feat(riot-client) Lambda Function 사용해서 API 호출이 가장 많은 메서드 대체

### DIFF
--- a/src/main/java/com/summoner/lolhaeduo/client/riot/RiotClient.java
+++ b/src/main/java/com/summoner/lolhaeduo/client/riot/RiotClient.java
@@ -134,6 +134,38 @@ public class RiotClient {
     }
 
     public FormattedMatchResponse getMatchDetails(String matchId, String summonerName, String tagLine, AccountRegion region) {
+//        // Choose regional URL
+//        String baseUrl = regionBaseUrls.getOrDefault(region.toString(), null);
+//        if (baseUrl == null) {
+//            throw new IllegalArgumentException("Invalid region specified: " + region);
+//        }
+//
+//        // Set request URL
+//        String url = String.format(
+//                "%s/lol/match/v5/matches/%s?api_key=%s",
+//                baseUrl, matchId, apiKey
+//        );
+//
+//        MatchResponse matchResponse = restTemplate.getForObject(url, MatchResponse.class);
+//        if (matchResponse == null || matchResponse.getInfo() == null || matchResponse.getInfo().getParticipants() == null) {
+//            throw new IllegalArgumentException("Invalid match specified: " + matchId);
+//        }
+//
+//        // Filter participants
+//        return matchResponse.getInfo().getParticipants().stream()
+//                .filter(p -> summonerName.equals(p.getRiotIdGameName()) && tagLine.equals(p.getRiotIdTagline()))
+//                .map(target -> new FormattedMatchResponse(
+//                        target.getChampionName(),
+//                        target.getKills(),
+//                        target.getDeaths(),
+//                        target.getAssists(),
+//                        target.isWin()
+//                ))
+//                .findFirst()
+//                .orElseThrow(
+//                        () -> new IllegalArgumentException("No matching participant found in the match")
+//                );
+
         // 직접 제작한 Lambda Function 으로 랜덤한 매치 데이터를 받습니다.
         String baseUrl = "https://oprimofm4f.execute-api.ap-northeast-2.amazonaws.com/default/getMatchDetails";
 

--- a/src/main/java/com/summoner/lolhaeduo/client/riot/RiotClient.java
+++ b/src/main/java/com/summoner/lolhaeduo/client/riot/RiotClient.java
@@ -134,7 +134,7 @@ public class RiotClient {
     }
 
     public FormattedMatchResponse getMatchDetails(String matchId, String summonerName, String tagLine, AccountRegion region) {
-        // 직접 제젝한 Lambda Function 으로 랜덤한 매치 데이터를 받습니다.
+        // 직접 제작한 Lambda Function 으로 랜덤한 매치 데이터를 받습니다.
         String baseUrl = "https://oprimofm4f.execute-api.ap-northeast-2.amazonaws.com/default/getMatchDetails";
 
         ResponseEntity<FormattedMatchResponse> response = restTemplate.getForEntity(baseUrl, FormattedMatchResponse.class);

--- a/src/main/java/com/summoner/lolhaeduo/client/riot/RiotClient.java
+++ b/src/main/java/com/summoner/lolhaeduo/client/riot/RiotClient.java
@@ -1,6 +1,9 @@
 package com.summoner.lolhaeduo.client.riot;
 
-import com.summoner.lolhaeduo.client.dto.*;
+import com.summoner.lolhaeduo.client.dto.FormattedMatchResponse;
+import com.summoner.lolhaeduo.client.dto.LeagueEntryResponse;
+import com.summoner.lolhaeduo.client.dto.PuuidResponse;
+import com.summoner.lolhaeduo.client.dto.SummonerResponse;
 import com.summoner.lolhaeduo.domain.account.enums.AccountRegion;
 import com.summoner.lolhaeduo.domain.account.enums.AccountServer;
 import lombok.RequiredArgsConstructor;
@@ -131,36 +134,10 @@ public class RiotClient {
     }
 
     public FormattedMatchResponse getMatchDetails(String matchId, String summonerName, String tagLine, AccountRegion region) {
-        // Choose regional URL
-        String baseUrl = regionBaseUrls.getOrDefault(region.toString(), null);
-        if (baseUrl == null) {
-            throw new IllegalArgumentException("Invalid region specified: " + region);
-        }
+        // 직접 제젝한 Lambda Function 으로 랜덤한 매치 데이터를 받습니다.
+        String baseUrl = "https://oprimofm4f.execute-api.ap-northeast-2.amazonaws.com/default/getMatchDetails";
 
-        // Set request URL
-        String url = String.format(
-            "%s/lol/match/v5/matches/%s?api_key=%s",
-            baseUrl, matchId, apiKey
-        );
-
-        MatchResponse matchResponse = restTemplate.getForObject(url, MatchResponse.class);
-        if (matchResponse == null || matchResponse.getInfo() == null || matchResponse.getInfo().getParticipants() == null) {
-            throw new IllegalArgumentException("Invalid match specified: " + matchId);
-        }
-
-        // Filter participants
-        return matchResponse.getInfo().getParticipants().stream()
-            .filter(p -> summonerName.equals(p.getRiotIdGameName()) && tagLine.equals(p.getRiotIdTagline()))
-            .map(target -> new FormattedMatchResponse(
-                    target.getChampionName(),
-                    target.getKills(),
-                    target.getDeaths(),
-                    target.getAssists(),
-                    target.isWin()
-            ))
-            .findFirst()
-            .orElseThrow(
-                () -> new IllegalArgumentException("No matching participant found in the match")
-            );
+        ResponseEntity<FormattedMatchResponse> response = restTemplate.getForEntity(baseUrl, FormattedMatchResponse.class);
+        return response.getBody();
     }
 }


### PR DESCRIPTION
## ✨ 담당 파트
- 목 라이엇 서버 연결

## 🔎 작업 상세 내용
- 전적 상세 정보를 가져오는 메서드(가 가장 호출량이 많았기에 이거만 대체했습니다.)

## 🔧 앞으로의 과제
- 단위 API별 호출시간을 계산해서 지연시간을 추가해서 실제 라이엇 서버에서 호출 오는 것처럼 지연을 주려고 합니다.

## ✅ 테스트 코드 작성 및 기능 테스트 여부
- [] 테스트 코드 작성
- [] 기능 테스트 여부

## ➕ 이슈 링크
- #41