### PR TITLE
feat: RestTemplate을 이용한 Riot API 호출 메트릭 기록 및 Rate Limit 모니터링 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,11 @@ dependencies {
 
     // H2 데이터베이스
     runtimeOnly 'com.h2database:h2'
+
+    // Spring Boot Actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    // Micrometer Prometheus Registry
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
## ✨ 담당 파트
- RestTemplate을 이용한 Riot API 호출 메트릭 기록 및 Rate Limit 모니터링 기능 추가
<br>

## 🔎 작업 상세 내용
1. 모니터링을 위한 Spring Boot Actuator 와 Prometheus Micrometer Registry 의존성 추가

2. MeterRegistry 를 활용한 응답 시간 메트릭 기록

3. X-Rate-Limit-Remaining 헤더를 확인하여, Rate Limit 초과 여부 모니터링

4. API 호출 에러 발생 시, 메트릭 기록
<br>

## 🔧 앞으로의 과제
- Riot API 호출에 대한 모니터링 결과 자료화
- CPU, 메모리 사용량에 대한 모니터링 추가
- 문제 파악을 위한 테스트 코드 작성 및 모니터링
  → 시나리오 잘 생각해보기
- EC2에 모니터링 서버 구축
<br>

## ✅ 테스트 코드 작성 및 기능 테스트 여부
- [ ] 테스트 코드 작성
- [x] 기능 테스트 여부
<br>

## ➕ 이슈 링크
- #38 