### PR TITLE
Account 중복확인 로직 추가, Account 연동 시 AccountId 값 반환

### DIFF
--- a/src/main/java/com/summoner/lolhaeduo/domain/account/dto/LinkAccountRequest.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/account/dto/LinkAccountRequest.java
@@ -12,7 +12,7 @@ public class LinkAccountRequest {
     private AccountType accountType;
 
     @NotNull
-    private String accountId;
+    private String accountUsername;
 
     @NotNull
     private String accountPassword;

--- a/src/main/java/com/summoner/lolhaeduo/domain/account/dto/LinkAccountResponse.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/account/dto/LinkAccountResponse.java
@@ -1,0 +1,16 @@
+package com.summoner.lolhaeduo.domain.account.dto;
+
+import lombok.Getter;
+
+@Getter
+public class LinkAccountResponse {
+    private Long accountId;
+
+    private LinkAccountResponse(Long accountId) {
+        this.accountId = accountId;
+    }
+
+    public static LinkAccountResponse of(Long accountId) {
+        return new LinkAccountResponse(accountId);
+    }
+}

--- a/src/main/java/com/summoner/lolhaeduo/domain/account/repository/AccountRepository.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/account/repository/AccountRepository.java
@@ -3,10 +3,7 @@ package com.summoner.lolhaeduo.domain.account.repository;
 import com.summoner.lolhaeduo.domain.account.entity.Account;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface AccountRepository extends JpaRepository<Account, Long>, AccountQuerydslRepository{
     boolean existsByUsername(String username);
     boolean existsBySummonerNameAndTagLine(String summonerName, String tagLine);
-    Optional<Account> findBySummonerNameAndTagLine(String summonerName, String tagLine);
 }

--- a/src/main/java/com/summoner/lolhaeduo/domain/account/repository/AccountRepository.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/account/repository/AccountRepository.java
@@ -3,7 +3,10 @@ package com.summoner.lolhaeduo.domain.account.repository;
 import com.summoner.lolhaeduo.domain.account.entity.Account;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface AccountRepository extends JpaRepository<Account, Long>, AccountQuerydslRepository{
     boolean existsByUsername(String username);
     boolean existsBySummonerNameAndTagLine(String summonerName, String summonerName1);
+    Optional<Account> findBySummonerNameAndTagLine(String summonerName, String summonerName1);
 }

--- a/src/main/java/com/summoner/lolhaeduo/domain/account/repository/AccountRepository.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/account/repository/AccountRepository.java
@@ -7,6 +7,6 @@ import java.util.Optional;
 
 public interface AccountRepository extends JpaRepository<Account, Long>, AccountQuerydslRepository{
     boolean existsByUsername(String username);
-    boolean existsBySummonerNameAndTagLine(String summonerName, String summonerName1);
+    boolean existsBySummonerNameAndTagLine(String summonerName, String tagLine);
     Optional<Account> findBySummonerNameAndTagLine(String summonerName, String tagLine);
 }

--- a/src/main/java/com/summoner/lolhaeduo/domain/account/repository/AccountRepository.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/account/repository/AccountRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 public interface AccountRepository extends JpaRepository<Account, Long>, AccountQuerydslRepository{
     boolean existsByUsername(String username);
     boolean existsBySummonerNameAndTagLine(String summonerName, String summonerName1);
-    Optional<Account> findBySummonerNameAndTagLine(String summonerName, String summonerName1);
+    Optional<Account> findBySummonerNameAndTagLine(String summonerName, String tagLine);
 }

--- a/src/main/java/com/summoner/lolhaeduo/domain/account/repository/AccountRepository.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/account/repository/AccountRepository.java
@@ -5,6 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AccountRepository extends JpaRepository<Account, Long>, AccountQuerydslRepository{
     boolean existsByUsername(String username);
-
-    Account findByMemberId(Long memberId);
+    boolean existsBySummonerNameAndTagLine(String summonerName, String summonerName1);
 }

--- a/src/main/java/com/summoner/lolhaeduo/domain/account/service/AccountService.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/account/service/AccountService.java
@@ -38,6 +38,10 @@ public class AccountService {
             throw new IllegalArgumentException("Account already exists");
         }
 
+        if (accountRepository.existsBySummonerNameAndTagLine(request.getSummonerName(), request.getTagLine())) {
+            throw new IllegalArgumentException("Account has been linked by another member");
+        }
+
         if (request.getAccountType().equals(RIOT)) {
             AccountDetail newAccountDetail = riotClientService.createAccountDetail(request);
 

--- a/src/main/java/com/summoner/lolhaeduo/domain/account/service/AccountService.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/account/service/AccountService.java
@@ -35,10 +35,6 @@ public class AccountService {
             throw new IllegalArgumentException("Account limit(3) exceeded");
         }
 
-        if (accountRepository.existsByUsername(request.getAccountUsername())) {
-            throw new IllegalArgumentException("Account already exists");
-        }
-
         if (accountRepository.existsBySummonerNameAndTagLine(request.getSummonerName(), request.getTagLine())) {
             throw new IllegalArgumentException("Account has been linked by another member");
         }

--- a/src/main/java/com/summoner/lolhaeduo/domain/duo/dto/DuoCreateRequest.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/duo/dto/DuoCreateRequest.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 @Getter
 public class DuoCreateRequest {
 
-    private Long accountId;
+    private String summonerName;
+    private String tagLine;
     private QueueType queueType;
     private Lane primaryRole;
     private String primaryChamp;
@@ -16,10 +17,4 @@ public class DuoCreateRequest {
     private Lane targetRole;
     private String memo;
     private Boolean mic;
-
-
-    public void validate() {
-        // 여기서 null 체크
-        //
-    }
 }

--- a/src/main/java/com/summoner/lolhaeduo/domain/duo/dto/DuoCreateRequest.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/duo/dto/DuoCreateRequest.java
@@ -7,8 +7,7 @@ import lombok.Getter;
 @Getter
 public class DuoCreateRequest {
 
-    private String summonerName;
-    private String tagLine;
+    private Long accountId;
     private QueueType queueType;
     private Lane primaryRole;
     private String primaryChamp;

--- a/src/main/java/com/summoner/lolhaeduo/domain/duo/service/DuoService.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/duo/service/DuoService.java
@@ -63,7 +63,7 @@ public class DuoService {
     @Transactional
     public DuoCreateResponse createDuo(DuoCreateRequest request, Long memberId) {
 
-        Account linkedAccount = accountRepository.findById(request.getAccountId()).orElseThrow(
+        Account linkedAccount = accountRepository.findBySummonerNameAndTagLine(request.getSummonerName(), request.getTagLine()).orElseThrow(
                 () -> new IllegalArgumentException("Not Found Account")
         );
 

--- a/src/main/java/com/summoner/lolhaeduo/domain/duo/service/DuoService.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/duo/service/DuoService.java
@@ -63,7 +63,7 @@ public class DuoService {
     @Transactional
     public DuoCreateResponse createDuo(DuoCreateRequest request, Long memberId) {
 
-        Account linkedAccount = accountRepository.findBySummonerNameAndTagLine(request.getSummonerName(), request.getTagLine()).orElseThrow(
+        Account linkedAccount = accountRepository.findById(request.getAccountId()).orElseThrow(
                 () -> new IllegalArgumentException("Not Found Account")
         );
 


### PR DESCRIPTION
## ✨ 담당 파트
- Account 중복확인 로직 추가

## 🔎 작업 상세 내용
- 이미 등록된 계정의 경우 중복으로 다른 멤버에게 등록되지 않도록 중복확인 로직을 추가했습니다.
- 추가로 듀오 등록 시 AccountId 값을 적어야 하는데, 현재 Account 등록 시 AccountId를 확인하기 위해서는 DB에 적힌 값을 확인해야 하기 때문에, 알기 쉬운 SummonerName과 TagLine으로 생성할 수 있도록 수정했습니다.

## 🔧 앞으로의 과제
- X

## ✅ 테스트 코드 작성 및 기능 테스트 여부
- [ ] 테스트 코드 작성
- [x] 기능 테스트 여부

## ➕ 이슈 링크
- 