### PR TITLE
API 호출 속도 대폭 향상

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     // Micrometer Prometheus Registry
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
+    // Spring retry
+    implementation 'org.springframework.retry:spring-retry'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/summoner/lolhaeduo/common/config/RetryConfig.java
+++ b/src/main/java/com/summoner/lolhaeduo/common/config/RetryConfig.java
@@ -1,0 +1,9 @@
+package com.summoner.lolhaeduo.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@EnableRetry
+@Configuration
+public class RetryConfig {
+}

--- a/src/main/java/com/summoner/lolhaeduo/domain/account/service/AccountGameDataService.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/account/service/AccountGameDataService.java
@@ -16,6 +16,7 @@ import com.summoner.lolhaeduo.domain.account.repository.dataStorage.QuickGameDat
 import com.summoner.lolhaeduo.domain.account.repository.dataStorage.SoloRankDataRepository;
 import com.summoner.lolhaeduo.domain.duo.entity.Kda;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
@@ -26,6 +27,7 @@ import java.util.List;
 
 import static com.summoner.lolhaeduo.domain.duo.enums.QueueType.*;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AccountGameDataService {
@@ -44,6 +46,7 @@ public class AccountGameDataService {
         Account account = accountRepository.findById(event.getAccountId()).orElseThrow(
                 () -> new IllegalArgumentException("Account not found")
         );
+        long startTime = System.currentTimeMillis();
 
         // 랭크 정보 가져오기
         RankStats rankStats = riotClientService.getRankGameStats(account.getAccountDetail().getEncryptedSummonerId(), account.getServer());
@@ -93,6 +96,8 @@ public class AccountGameDataService {
         String iconUrl = riotClientService.updateProfileIconUrl(account);
 
         AccountGameData newAccountGameData = AccountGameData.of(iconUrl, quickGameData, soloRankData, flexRankData);
+        long endTime = System.currentTimeMillis();
+        log.info("API latency : " + (endTime - startTime));
         account.linkAccountGameData(newAccountGameData);
 
         accountGameDataRepository.save(newAccountGameData);


### PR DESCRIPTION
## ✨ 담당 파트
- RiotClientService, RiotClient 내 API 호출 로직 수정 

## 🔎 작업 상세 내용
- RiotClientService의 getMatchStats의 반복되는 API 호출을 합치고, 기존의 for loop에서 차례차례 수행되던 호출 방식 대신 스레드 풀을 사용해서 API 호출이 여러 스레드에서 동시에 호출될 수 있도록 수정했습니다.
- 그리고 스레드 풀을 10개 이상으로 설정할 시 오류가 발생하는데, 이는 람다 Function의 Concurrency 할당량이 10으로 정해져 있었기 떄문입니다. 이를 올리기 위해서는 추가 과금이 필요합니다. 따라서 추가적인 과금이 일어나지 않도록 할당량을 유지한 채 문제를 해결할 수 있는 방법을 고안해 보았습니다.
- 이 PR에서는 재시도 로직을 추가해서 해결해보려고 했습니다. 재처리 횟수를 조정하고, 대기 시간을 조정하고, 또 모두 실패한 경우 로그를 남기도록 코드를 작성했습니다. 하지만, 더 많은 계정 연동 요청이 들어오게 될 경우 재시도 로직이 실패할 가능성이 있습니다. 따라서 재시도 로직은 전체 호출 성공률을 크게 높이는데 기여하는 우수한 성능을 보여줬지만, 근본적으로 완벽한 해결방안이 될 수 없기에 추가로 RateLimiter같은 호출을 능동적으로 막게 해줄 로직이 필요할 것 같습니다.
- 현재 재시도 로직으로 대기시간을 5초, 재시도 횟수를 5회로 만들어 놓았는데, 기본값은 대기시간 10초, 재시도 횟수 3번입니다. 대기시간이 너무 긴 것 같아 5초로 줄인 상황에서 3회/5초에서 실행해 보았음에도 API 호출 900회 + 500회 시 가끔씩 503 에러가 발생했기 때문에, 5초/5회로 설정했습니다.
- 자세한 사진 설명을 위해서 브로셔 트러블슈팅 3번과 4번 항목을 확인해주세요!

## 🔧 앞으로의 과제
- RateLimiter를 사용해서 호출량 제한

## ✅ 테스트 코드 작성 및 기능 테스트 여부
- [ ] 테스트 코드 작성
- [x] 기능 테스트 여부

## ➕ 이슈 링크
- #62 